### PR TITLE
Add SwayFX installation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,23 @@ set -xu
 
 readonly RELEASE="$(rpm -E %fedora)"
 
+# For COPR enablement, pass in `user` and `project`
+function copr_enable {
+  if [[ "$#" -ne 2 ]]; then
+    printf '%s expected 2 arguments, got %i' "$0" "$#"
+    return 1
+  fi
+  local copr_user="$1"
+  local copr_project="$2"
+  local copr_dest="/usr/etc/yum.repos.d/_copr:copr.fedorainfracloud.org:$copr_user:$copr_project.repo"
+  local copr_url="https://copr.fedorainfracloud.org/coprs/$copr_user/$copr_project/repo/fedora-$RELEASE/$copr_user-$copr_project-fedora-$RELEASE.repo"
+  if wget --secure-protocol=TLSv1_3 -O "$copr_dest" "$copr_url"; then
+    # TODO: maybe some checksumming, GPG verification, etc.
+    return 0
+  fi
+  return 1
+}
+
 ## Installations
 
 # Packages can be installed from any enabled yum repo on the image.
@@ -16,7 +33,7 @@ readonly RELEASE="$(rpm -E %fedora)"
 # Should be able to use `dnf` for builds:
 #   https://github.com/coreos/rpm-ostree/issues/718#issuecomment-2125711817
 
-dnf copr enable swayfx/swayfx \
+copr_enable swayfx swayfx \
 && dnf install --setopt=install_weak_deps=false -y swayfx \
 && dnf install -y sway-systemd swayidle qt5-qtwayland qt6-qtwayland \
 || exit 1

--- a/build.sh
+++ b/build.sh
@@ -26,14 +26,16 @@ function copr_enable {
 
 ## Installations
 
+rpm-ostree install dnf5
+
 # Packages can be installed from any enabled yum repo on the image.
 # RPMfusion repos are available by default in ublue main images
 # List of rpmfusion packages can be found here:
 #   https://mirrors.rpmfusion.org/mirrorlist?path=free/fedora/updates/39/x86_64/repoview/index.html&protocol=https&redirect=1
-# Should be able to use `dnf` for builds:
+# TODO: test using `dnf` for builds:
 #   https://github.com/coreos/rpm-ostree/issues/718#issuecomment-2125711817
 
-copr_enable swayfx swayfx \
+dnf copr enable swayfx/swayfx \
 && dnf install --setopt=install_weak_deps=false -y swayfx \
 && dnf install -y sway-systemd swayidle qt5-qtwayland qt6-qtwayland \
 || exit 1
@@ -56,4 +58,6 @@ printf 'swaybg_command -' > /usr/etc/sway/config.d/20-swaybg-command.conf
 
 ## Finishing
 
-dnf clean all || exit 1
+dnf clean all \
+&& rpm-ostree uninstall dnf5 \
+|| exit 1

--- a/build.sh
+++ b/build.sh
@@ -1,23 +1,42 @@
 #!/bin/bash
+# NOTE: change `set` flags to accommodate edge cases
+# set -ouex pipefail
+set -xu
 
-set -ouex pipefail
+## Setup
 
-RELEASE="$(rpm -E %fedora)"
+readonly RELEASE="$(rpm -E %fedora)"
 
-
-### Install packages
+## Installations
 
 # Packages can be installed from any enabled yum repo on the image.
 # RPMfusion repos are available by default in ublue main images
 # List of rpmfusion packages can be found here:
-# https://mirrors.rpmfusion.org/mirrorlist?path=free/fedora/updates/39/x86_64/repoview/index.html&protocol=https&redirect=1
+#   https://mirrors.rpmfusion.org/mirrorlist?path=free/fedora/updates/39/x86_64/repoview/index.html&protocol=https&redirect=1
+# Should be able to use `dnf` for builds:
+#   https://github.com/coreos/rpm-ostree/issues/718#issuecomment-2125711817
 
-# this installs a package from fedora repos
-rpm-ostree install screen
+dnf copr enable swayfx/swayfx \
+&& dnf install --setopt=install_weak_deps=false -y swayfx \
+&& dnf install -y sway-systemd swayidle qt5-qtwayland qt6-qtwayland \
+|| exit 1
 
-# this would install a package from rpmfusion
-# rpm-ostree install vlc
+## Removals
+# TODO: `dnf swap` sway-wallpapers and swaybg and override default config
 
-#### Example for enabling a System Unit File
+## Configurations
 
-systemctl enable podman.socket
+# Overwrite the default sway configs
+# TODO: consider `dnf swap` to sway-config-minimal
+mkdir -p /usr/etc/sway/config.d/ \
+&& mv -n /etc/sway/* /usr/etc/sway/ \ 
+&& sed -i.orig \
+  -e '/^set \$term foot/c\set \$term ptyxis' \
+  -e '/^output \* bg/c\output \* bg \/usr\/share\/backgrounds\/f40\/default\/f40-01-day.png fit' \
+  /usr/etc/sway/config \
+|| exit 1
+printf 'swaybg_command -' > /usr/etc/sway/config.d/20-swaybg-command.conf
+
+## Finishing
+
+dnf clean all || exit 1

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # NOTE: change `set` flags to accommodate edge cases
-# set -ouex pipefail
-set -xu
+set -ouex pipefail
 
 ## Setup
 
@@ -35,10 +34,9 @@ rpm-ostree install dnf5
 # TODO: test using `dnf` for builds:
 #   https://github.com/coreos/rpm-ostree/issues/718#issuecomment-2125711817
 
-dnf copr enable swayfx/swayfx \
-&& dnf install --setopt=install_weak_deps=false -y swayfx \
-&& dnf install -y sway-systemd swayidle qt5-qtwayland qt6-qtwayland \
-|| exit 1
+dnf5 copr enable swayfx/swayfx
+dnf5 install --setopt=install_weak_deps=false -y swayfx
+dnf5 install -y sway-systemd swayidle qt5-qtwayland qt6-qtwayland
 
 ## Removals
 # TODO: `dnf swap` sway-wallpapers and swaybg and override default config
@@ -47,17 +45,15 @@ dnf copr enable swayfx/swayfx \
 
 # Overwrite the default sway configs
 # TODO: consider `dnf swap` to sway-config-minimal
-mkdir -p /usr/etc/sway/config.d/ \
-&& mv -n /etc/sway/* /usr/etc/sway/ \ 
-&& sed -i.orig \
+mkdir -p /usr/etc/sway/config.d/
+mv -n /etc/sway/* /usr/etc/sway/
+sed -i.orig \
   -e '/^set \$term foot/c\set \$term ptyxis' \
   -e '/^output \* bg/c\output \* bg \/usr\/share\/backgrounds\/f40\/default\/f40-01-day.png fit' \
-  /usr/etc/sway/config \
-|| exit 1
+  /usr/etc/sway/config
 printf 'swaybg_command -' > /usr/etc/sway/config.d/20-swaybg-command.conf
 
 ## Finishing
 
-dnf clean all \
-&& rpm-ostree uninstall dnf5 \
-|| exit 1
+dnf5 clean all
+rpm-ostree uninstall dnf5

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ set -ouex pipefail
 readonly RELEASE="$(rpm -E %fedora)"
 
 # For COPR enablement, pass in `user` and `project`
+# Needed so we're installing to /usr/etc/yum.repos.d/
 function copr_enable {
   if [[ "$#" -ne 2 ]]; then
     printf '%s expected 2 arguments, got %i' "$0" "$#"
@@ -34,7 +35,7 @@ rpm-ostree install dnf5
 # TODO: test using `dnf` for builds:
 #   https://github.com/coreos/rpm-ostree/issues/718#issuecomment-2125711817
 
-dnf5 copr enable swayfx/swayfx
+copr_enable swayfx swayfx
 dnf5 install --setopt=install_weak_deps=false -y swayfx
 dnf5 install -y sway-systemd swayidle qt5-qtwayland qt6-qtwayland
 

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 # NOTE: change `set` flags to accommodate edge cases
 set -ouex pipefail
 
+# NOTE: For /etc vs. /usr/etc, see: https://github.com/ublue-os/bluefin/pull/441#issuecomment-1694785648
+
 ## Setup
 
 readonly RELEASE="$(rpm -E %fedora)"
@@ -24,7 +26,6 @@ function copr_enable {
   local copr_url="https://copr.fedorainfracloud.org/coprs/$copr_user/$copr_project/repo/fedora-$RELEASE/$copr_user-$copr_project-fedora-$RELEASE.repo"
   if _wget -O "$copr_dest" "$copr_url"; then
     # TODO: maybe some checksumming, GPG verification, etc.
-    cp "$copr_dest" "/usr/${copr_dest#/}" || return
     return 0
   fi
   return


### PR DESCRIPTION
Some initial configs to use ~`dnf`~ `rpm-ostree`+`dnf5` to install SwayFX with custom weak dependencies. Adjusted the default configs for `sway` to use Bluefin DX provided applications.